### PR TITLE
fix: Capitalize schema.org/url -> schema.org/URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openactive/data-model-validator",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "A library to allow a developer to validate a JSON document against the OpenActive Modelling Opportunity Specification",
   "homepage": "http://openactive.io",
   "author": "Pete Walker <pete@imin.co> (https://github.com/petewalker)",

--- a/src/classes/field.js
+++ b/src/classes/field.js
@@ -173,7 +173,7 @@ const Field = class {
           if (isUrlTemplate) {
             returnType = 'https://schema.org/urlTemplate';
           } else if (this.constructor.URL_REGEX.test(data)) {
-            returnType = 'https://schema.org/url';
+            returnType = 'https://schema.org/URL';
           }
         }
       }
@@ -348,7 +348,7 @@ Field.canBeTypeOfMapping = {
   'https://schema.org/Duration': 'https://schema.org/Text',
   'https://schema.org/Time': 'https://schema.org/Text',
   'https://schema.org/Integer': 'https://schema.org/Float',
-  'https://schema.org/url': 'https://schema.org/Text',
+  'https://schema.org/URL': 'https://schema.org/Text',
   'https://schema.org/urlTemplate': 'https://schema.org/Text',
 };
 

--- a/src/rules/consumer-notes/assume-event-status-rule-spec.js
+++ b/src/rules/consumer-notes/assume-event-status-rule-spec.js
@@ -14,7 +14,7 @@ describe('AssumeEventStatusRule', () => {
     fields: {
       eventStatus: {
         fieldName: 'eventStatus',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
         options: [
           'https://schema.org/EventCancelled',
           'https://schema.org/EventPostponed',

--- a/src/rules/consumer-notes/assume-no-gender-restriction-rule-spec.js
+++ b/src/rules/consumer-notes/assume-no-gender-restriction-rule-spec.js
@@ -14,7 +14,7 @@ describe('AssumeNoGenderRestrictionRule', () => {
     fields: {
       genderRestriction: {
         fieldName: 'genderRestriction',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
         options: [
           'https://openactive.io/Female',
           'https://openactive.io/Male',

--- a/src/rules/core/context-in-root-node-rule-spec.js
+++ b/src/rules/core/context-in-root-node-rule-spec.js
@@ -173,7 +173,7 @@ describe('ContextInRootNodeRule', () => {
       ],
       fields: {
         '@context': {
-          requiredType: 'ArrayOf#https://schema.org/url',
+          requiredType: 'ArrayOf#https://schema.org/URL',
         },
       },
     }, 'latest');

--- a/src/rules/core/context-in-root-node-rule.js
+++ b/src/rules/core/context-in-root-node-rule.js
@@ -60,9 +60,9 @@ module.exports = class ContextInRootNodeRule extends Rule {
     // Is this the root node?
     if (node.parentNode === null || !node.parentNode.model.isJsonLd) {
       const backupField = new Field({
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
         alternativeTypes: [
-          'ArrayOf#https://schema.org/url',
+          'ArrayOf#https://schema.org/URL',
         ],
       }, node.options.version);
 

--- a/src/rules/core/fields-correct-type-rule-spec.js
+++ b/src/rules/core/fields-correct-type-rule-spec.js
@@ -230,7 +230,7 @@ describe('FieldsCorrectTypeRule', () => {
       fields: {
         field: {
           fieldName: 'field',
-          requiredType: 'https://schema.org/url',
+          requiredType: 'https://schema.org/URL',
         },
       },
     }, 'latest');
@@ -267,7 +267,7 @@ describe('FieldsCorrectTypeRule', () => {
       fields: {
         field: {
           fieldName: 'field',
-          requiredType: 'https://schema.org/url',
+          requiredType: 'https://schema.org/URL',
         },
       },
     }, 'latest');
@@ -778,7 +778,7 @@ describe('FieldsCorrectTypeRule', () => {
         },
         url_array: {
           fieldName: 'url_array',
-          requiredType: 'ArrayOf#https://schema.org/url',
+          requiredType: 'ArrayOf#https://schema.org/URL',
         },
         date_array: {
           fieldName: 'date_array',
@@ -878,7 +878,7 @@ describe('FieldsCorrectTypeRule', () => {
         },
         url_array: {
           fieldName: 'integer_array',
-          requiredType: 'ArrayOf#https://schema.org/url',
+          requiredType: 'ArrayOf#https://schema.org/URL',
         },
         date_array: {
           fieldName: 'float_array',
@@ -983,7 +983,7 @@ describe('FieldsCorrectTypeRule', () => {
         },
         url_array: {
           fieldName: 'url_array',
-          requiredType: 'ArrayOf#https://schema.org/url',
+          requiredType: 'ArrayOf#https://schema.org/URL',
         },
         date_array: {
           fieldName: 'date_array',
@@ -1045,7 +1045,7 @@ describe('FieldsCorrectTypeRule', () => {
       fields: {
         field: {
           fieldName: 'field',
-          requiredType: 'https://schema.org/url',
+          requiredType: 'https://schema.org/URL',
           model: '#Schedule',
           alternativeTypes: [
             'https://schema.org/DateTime',
@@ -1091,7 +1091,7 @@ describe('FieldsCorrectTypeRule', () => {
       fields: {
         field: {
           fieldName: 'field',
-          requiredType: 'https://schema.org/url',
+          requiredType: 'https://schema.org/URL',
           model: '#Schedule',
           alternativeTypes: [
             'https://schema.org/DateTime',

--- a/src/rules/core/fields-correct-type-rule.js
+++ b/src/rules/core/fields-correct-type-rule.js
@@ -105,7 +105,7 @@ module.exports = class FieldsCorrectTypeRule extends Rule {
         return `[\`string${plural}\` containing an ISO 8601 Time](${type})`;
       case 'https://schema.org/Duration':
         return `[\`string${plural}\` containing an ISO 8601 Duration](${type})`;
-      case 'https://schema.org/url':
+      case 'https://schema.org/URL':
         return `[\`string${plural}\` containing a url](${type})`;
       case 'https://schema.org/urlTemplate':
         return `[\`string${plural}\` containing a urlTemplate](${type})`;
@@ -156,7 +156,7 @@ module.exports = class FieldsCorrectTypeRule extends Rule {
       case 'https://schema.org/Duration':
         example = `${prefix}"PT30M"`;
         break;
-      case 'https://schema.org/url':
+      case 'https://schema.org/URL':
         example = `${prefix}"https://www.example.org/"`;
         break;
       case 'https://schema.org/urlTemplate':

--- a/src/rules/core/no-prefix-or-namespace-rule-spec.js
+++ b/src/rules/core/no-prefix-or-namespace-rule-spec.js
@@ -8,7 +8,7 @@ describe('NoPrefixOrNamespaceRule', () => {
   const model = new Model({
     type: 'Event',
     hasId: true,
-    idFormat: 'https://schema.org/url',
+    idFormat: 'https://schema.org/URL',
     inSpec: [
       '@context',
       'id',

--- a/src/rules/core/value-is-required-content-rule-spec.js
+++ b/src/rules/core/value-is-required-content-rule-spec.js
@@ -10,7 +10,7 @@ describe('ValueIsRequiredContentRule', () => {
     fields: {
       eventStatus: {
         fieldName: 'eventStatus',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
         requiredContent: 'https://schema.org/EventScheduled',
       },
     },

--- a/src/rules/data-quality/concept-id-in-scheme-rule-spec.js
+++ b/src/rules/data-quality/concept-id-in-scheme-rule-spec.js
@@ -12,11 +12,11 @@ describe('ConceptIdInSchemeRule', () => {
     fields: {
       id: {
         fieldName: 'id',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
       },
       inScheme: {
         fieldName: 'inScheme',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
       },
     },
   }, 'latest');

--- a/src/rules/data-quality/concept-no-props-if-inscheme-rule-spec.js
+++ b/src/rules/data-quality/concept-no-props-if-inscheme-rule-spec.js
@@ -13,15 +13,15 @@ describe('ConceptNoPropsIfInSchemeRule', () => {
     fields: {
       inScheme: {
         fieldName: 'inScheme',
-        requiredType: 'https://schema.org/url',
+        requiredType: 'https://schema.org/URL',
       },
       broader: {
         fieldName: 'broader',
-        requiredType: 'ArrayOf#https://schema.org/url',
+        requiredType: 'ArrayOf#https://schema.org/URL',
       },
       narrower: {
         fieldName: 'narrower',
-        requiredType: 'ArrayOf#https://schema.org/url',
+        requiredType: 'ArrayOf#https://schema.org/URL',
       },
     },
   }, 'latest');


### PR DESCRIPTION
schema.org/url is the property; schema.org/URL is the type. But, the former was being used for type. This was causing tests to fail.

To check this for yourself:

1. Run `npm run test-no-lint` on your machine on the latest `master` branch. Observe that test fails 🚨❌🚨
2. Repeat with the `lukehesluke/fix-capitalize-schema-url` branch. Observe that tests pass 🔥✔️🔥

I've also incremented the version number to 1.1.24 to indicate the change