### PR TITLE
SW3: add a way for Rules to target certain modes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
         "exceptMethods": [
           "isFieldTargeted",
           "isModelTargeted",
+          "isModeTargeted",
           "validateRaw",
           "validateModel",
           "validateField"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
         "exceptMethods": [
           "isFieldTargeted",
           "isModelTargeted",
-          "isModeTargeted",
+          "isValidationModeTargeted",
           "validateRaw",
           "validateModel",
           "validateField"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ console.log(defaultRules);
 
 ## Adding rules
 
-To add a new rule, you will need to extend the [`Rule`](src/rules/rule.js) class. 
+To add a new rule, you will need to extend the [`Rule`](src/rules/rule.js) class.
 
 The rule name you create should:
 
@@ -73,7 +73,7 @@ The rule name you create should:
 
 Generally speaking, you **SHOULD NOT** implement both `validateModel` and `validateField` in the same rule.
 
-Independently, a rule can also target particular modes of use. It is used to restrict rules which should only apply during a particular usage of the models (e.g. an Order used during one of the booking phases - C1, C2 and B). By default, a rule will target all modes.
+Independently, a rule can also target particular modes of use. It is used to restrict rules which should only apply during a particular usage of the models (e.g. an Order used during one of the booking phases - C1Request, C2Response or PatchOrder). By default, a rule will target all modes.
 
 #### Model & field targetting
 
@@ -151,7 +151,7 @@ Each test can define:
     * `ValidationErrorSeverity.NOTICE`
     * `ValidationErrorSeverity.SUGGESTION`
   * `type` - The type of the error when returned. Should come from the [`ValidationErrorType`](src/errors/validation-error-type.js) enum.
-  
+
 #### Example
 
 ```js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ this.targetFields = {
 };
 ```
 
-### Mode targetting
+### Validation Mode targetting
 
 To target all modes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,13 @@ this.targetFields = {
 To target all modes:
 
 ```js
-this.targetModes = '*';
+this.targetValidationModes = '*';
 ```
 
 To target specific modes:
 
 ```js
-this.targetModes = ['C2', 'B'];
+this.targetValidationModes = [ValidationMode.C1Request, ValidationMode.C2Response];
 ```
 
 ### Metadata
@@ -268,7 +268,7 @@ class RequiredFieldsRule extends Rule {
   constructor(options) {
     super(options);
     this.targetModels = '*';
-    this.targetModes = '*';
+    this.targetValidationModes = '*';
     this.meta = {
       name: 'RequiredFieldsRule',
       description: 'Validates that all required fields are present in the JSON data.',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,10 @@ The rule name you create should:
 
 Generally speaking, you **SHOULD NOT** implement both `validateModel` and `validateField` in the same rule.
 
+Independently, a rule can also target particular modes of use. It is used to restrict rules which should only apply during a particular usage of the models (e.g. an Order used during one of the booking phases - C1, C2 and B). By default, a rule will target all modes.
+
+#### Model & field targetting
+
 There is a lot of flexibility in the way that you can target rules.
 
 To target all models at the top level:
@@ -105,6 +109,20 @@ this.targetFields = {
         'url'
     ]
 };
+```
+
+### Mode targetting
+
+To target all modes:
+
+```js
+this.targetModes = '*';
+```
+
+To target specific modes:
+
+```js
+this.targetModes = ['C2', 'B'];
 ```
 
 ### Metadata
@@ -250,6 +268,7 @@ class RequiredFieldsRule extends Rule {
   constructor(options) {
     super(options);
     this.targetModels = '*';
+    this.targetModes = '*';
     this.meta = {
       name: 'RequiredFieldsRule',
       description: 'Validates that all required fields are present in the JSON data.',

--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ const result = validate(model, options);
 
 #### mode
 
-Provides context as to usage mode that data should be validated against.
+Provides context as to how the data under validation is expected to be used and therefore some validation rules may or may not apply.
+For example, OrderQuotes only have a customer attribute in the C2 phase and beyond of booking (so not in C1Request or C1Response nor nor any more generic published open data usage).
 
 e.g. To only apply rules that are suitable for data used in a booking flow phase like C2Request:
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,24 @@ const result = validate(model, options);
 #### mode
 
 Provides context as to usage mode that data should be validated against.
-For example, to only apply rules that are suitable for data used in a booking flow phase like C1, C2 or B.
+
+e.g. To only apply rules that are suitable for data used in a booking flow phase like C2Request:
+
+```js
+const { validate, ValidationMode } = require('@openactive/data-model-validator');
+
+const model = {
+  type: 'CustomAction'
+  // ...
+};
+
+const options = {
+  mode: ValidationMode.C2Request
+  // ...
+};
+
+const result = validate(model, options);
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ const options = {
 const result = validate(model, options);
 ```
 
+#### mode
+
+Provides context as to usage mode that data should be validated against.
+For example, to only apply rules that are suitable for data used in a booking flow phase like C1, C2 or B.
+
 ## Development
 
 ### Getting started

--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ const options = {
 const result = validate(model, options);
 ```
 
-#### mode
+#### validationMode
 
 Provides context as to how the data under validation is expected to be used and therefore some validation rules may or may not apply.
-For example, OrderQuotes only have a customer attribute in the C2 phase and beyond of booking (so not in C1Request or C1Response nor nor any more generic published open data usage).
+For example, OrderQuotes only have a customer attribute in the C2 phase and beyond of booking (so not in C1Request or C1Response nor any more generic published open data usage).
 
 e.g. To only apply rules that are suitable for data used in a booking flow phase like C2Request:
 
@@ -244,7 +244,7 @@ const model = {
 };
 
 const options = {
-  mode: ValidationMode.C2Request
+  validationMode: ValidationMode.C2Request
   // ...
 };
 

--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -1,3 +1,5 @@
+const ValidationMode = require('./validation-mode');
+
 const OptionsHelper = class {
   constructor(options) {
     this.options = options || {};
@@ -32,7 +34,7 @@ const OptionsHelper = class {
   }
 
   get mode() {
-    return this.options.mode || 'opendata';
+    return this.options.mode || ValidationMode.OpenData;
   }
 };
 

--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -30,6 +30,10 @@ const OptionsHelper = class {
   get version() {
     return this.options.version || 'latest';
   }
+
+  get mode() {
+    return this.options.mode || 'opendata';
+  }
 };
 
 module.exports = OptionsHelper;

--- a/src/helpers/options.js
+++ b/src/helpers/options.js
@@ -33,8 +33,8 @@ const OptionsHelper = class {
     return this.options.version || 'latest';
   }
 
-  get mode() {
-    return this.options.mode || ValidationMode.OpenData;
+  get validationMode() {
+    return this.options.validationMode || ValidationMode.OpenData;
   }
 };
 

--- a/src/helpers/validation-mode.js
+++ b/src/helpers/validation-mode.js
@@ -1,0 +1,25 @@
+const modeNames = [
+  'C1Request',
+  'C1Response',
+  'C2Request',
+  'C2Response',
+  'PRequest',
+  'PResponse',
+  'C1Request',
+  'C1Response',
+  'OrderProposalPatch',
+  'OrderPatch',
+  'OrderFeed',
+  'OrderStatus',
+  'OpenData',
+];
+
+const ValidationMode = Object.freeze(
+  modeNames.reduce((enums, modeName) => {
+    // eslint-disable-next-line no-param-reassign
+    enums[modeName] = modeName;
+    return enums;
+  }, {}),
+);
+
+module.exports = ValidationMode;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const ValidationError = require('./errors/validation-error');
 const ValidationErrorCategory = require('./errors/validation-error-category');
 const ValidationErrorType = require('./errors/validation-error-type');
 const ValidationErrorSeverity = require('./errors/validation-error-severity');
+const ValidationMode = require('./helpers/validation-mode');
 
 function createValidator() {
   const root = {
@@ -20,6 +21,7 @@ function createValidator() {
     ValidationErrorCategory,
     ValidationErrorType,
     ValidationErrorSeverity,
+    ValidationMode,
   };
   return root;
 }

--- a/src/rules/raw-rule.js
+++ b/src/rules/raw-rule.js
@@ -17,7 +17,7 @@ const RawRule = class extends Rule {
     return false;
   }
 
-  isModeTargeted() {
+  isValidationModeTargeted() {
     return false;
   }
 };

--- a/src/rules/raw-rule.js
+++ b/src/rules/raw-rule.js
@@ -16,6 +16,10 @@ const RawRule = class extends Rule {
   isFieldTargeted() {
     return false;
   }
+
+  isModeTargeted() {
+    return false;
+  }
 };
 
 

--- a/src/rules/rule.js
+++ b/src/rules/rule.js
@@ -7,6 +7,7 @@ class Rule {
     this.options = options || new OptionsHelper();
     this.targetModels = [];
     this.targetFields = {};
+    this.targetModes = '*';
     this.meta = {
       name: 'Rule',
       description: 'This is a base rule description that should be overridden.',
@@ -16,7 +17,11 @@ class Rule {
 
   validate(nodeToTest) {
     let errors = [];
-    // console.log(nodeToTest);
+
+    if (!this.isModeTargeted(nodeToTest.options.mode)) {
+      return errors;
+    }
+
     if (this.isModelTargeted(nodeToTest.model)) {
       errors = errors.concat(this.validateModel(nodeToTest));
     }
@@ -116,6 +121,17 @@ class Rule {
         }
       }
     }
+    return false;
+  }
+
+  isModeTargeted(mode) {
+    if (this.targetModes === '*') return true;
+
+
+    if (this.targetModes instanceof Array) {
+      return this.targetModes.includes(mode);
+    }
+
     return false;
   }
 }

--- a/src/rules/rule.js
+++ b/src/rules/rule.js
@@ -18,7 +18,7 @@ class Rule {
   validate(nodeToTest) {
     let errors = [];
 
-    if (!this.isModeTargeted(nodeToTest.options.validationMode)) {
+    if (!this.isValidationModeTargeted(nodeToTest.options.validationMode)) {
       return errors;
     }
 
@@ -124,7 +124,7 @@ class Rule {
     return false;
   }
 
-  isModeTargeted(validationMode) {
+  isValidationModeTargeted(validationMode) {
     if (this.targetValidationModes === '*') return true;
 
 

--- a/src/rules/rule.js
+++ b/src/rules/rule.js
@@ -7,7 +7,7 @@ class Rule {
     this.options = options || new OptionsHelper();
     this.targetModels = [];
     this.targetFields = {};
-    this.targetModes = '*';
+    this.targetValidationModes = '*';
     this.meta = {
       name: 'Rule',
       description: 'This is a base rule description that should be overridden.',
@@ -18,7 +18,7 @@ class Rule {
   validate(nodeToTest) {
     let errors = [];
 
-    if (!this.isModeTargeted(nodeToTest.options.mode)) {
+    if (!this.isModeTargeted(nodeToTest.options.validationMode)) {
       return errors;
     }
 
@@ -124,12 +124,12 @@ class Rule {
     return false;
   }
 
-  isModeTargeted(mode) {
-    if (this.targetModes === '*') return true;
+  isModeTargeted(validationMode) {
+    if (this.targetValidationModes === '*') return true;
 
 
-    if (this.targetModes instanceof Array) {
-      return this.targetModes.includes(mode);
+    if (this.targetValidationModes instanceof Array) {
+      return this.targetValidationModes.includes(validationMode);
     }
 
     return false;


### PR DESCRIPTION
Some Rules that are being created need to be restricted to only being applied when validating data used in certain modes. For example, customer data on an Order is only present during one of the the C2 and B booking phases as opposed to the more general publishing of open data.

By default all Rules will target all modes to start with since mode targeting is optional and in many of the more generic rules won't need to be considered.