### PR TITLE
Per validation mode required and recommended rules

### DIFF
--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -65,8 +65,15 @@ const Model = class {
     return PropertyHelper.arrayHasField(this.requiredFields, field, this.version);
   }
 
-  get requiredOptions() {
-    return this.data.requiredOptions || [];
+  getRequiredOptions(validationMode) {
+    let options;
+    const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
+    if (typeof specificImperativeConfiguration === 'object') {
+      options = specificImperativeConfiguration.requiredOptions;
+    } else {
+      options = this.data.requiredOptions;
+    }
+    return options || [];
   }
 
   get recommendedFields() {

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -40,8 +40,25 @@ const Model = class {
     return this.data.commonTypos || {};
   }
 
-  get requiredFields() {
-    return this.data.requiredFields || [];
+  getImperativeConfiguration(validationMode) {
+    if (
+      typeof this.validationMode === 'object'
+      && typeof this.validationMode[validationMode] === 'string'
+    ) {
+      return this.imperativeConfiguration[this.validationMode[validationMode]];
+    }
+    return undefined;
+  }
+
+  getRequiredFields(validationMode) {
+    let fields;
+    const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
+    if (typeof specificImperativeConfiguration === 'object') {
+      fields = specificImperativeConfiguration.requiredFields;
+    } else {
+      fields = this.data.requiredFields;
+    }
+    return fields || [];
   }
 
   hasRequiredField(field) {

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -76,8 +76,15 @@ const Model = class {
     return options || [];
   }
 
-  get recommendedFields() {
-    return this.data.recommendedFields || [];
+  getRecommendedFields(validationMode) {
+    let fields;
+    const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
+    if (typeof specificImperativeConfiguration === 'object') {
+      fields = specificImperativeConfiguration.recommendedFields;
+    } else {
+      fields = this.data.recommendedFields;
+    }
+    return fields || [];
   }
 
   hasRecommendedField(field) {

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -110,6 +110,14 @@ const Model = class {
     }
     return undefined;
   }
+
+  get validationMode() {
+    return this.data.validationMode;
+  }
+
+  get imperativeConfiguration() {
+    return this.data.imperativeConfiguration;
+  }
 };
 
 module.exports = Model;

--- a/src/rules/core/recommended-fields-rule-spec.js
+++ b/src/rules/core/recommended-fields-rule-spec.js
@@ -3,6 +3,8 @@ const Model = require('../../classes/model');
 const ModelNode = require('../../classes/model-node');
 const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+const ValidationMode = require('../../helpers/validation-mode');
+const OptionsHelper = require('../../helpers/options');
 
 describe('RecommendedFieldsRule', () => {
   const model = new Model({
@@ -11,6 +13,16 @@ describe('RecommendedFieldsRule', () => {
       'description',
       'name',
     ],
+    validationMode: {
+      C1Request: 'request',
+    },
+    imperativeConfiguration: {
+      request: {
+        recommendedFields: [
+          'duration',
+        ],
+      },
+    },
   }, 'latest');
   model.hasSpecification = true;
 
@@ -88,6 +100,50 @@ describe('RecommendedFieldsRule', () => {
       expect(error.type).toBe(ValidationErrorType.MISSING_RECOMMENDED_FIELD);
       expect(error.severity).toBe(ValidationErrorSeverity.WARNING);
     }
+  });
+
+  describe('when validation mode is on with separate required fields', () => {
+    const options = new OptionsHelper({ validationMode: ValidationMode.C1Request });
+
+    it('should return no errors if all required fields are present', () => {
+      const data = {
+        type: 'Event',
+        duration: 'PT1H30M',
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return a warning per field if any required fields are missing', () => {
+      const data = {
+        type: 'Event',
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(1);
+
+      for (const error of errors) {
+        expect(error.type).toBe(ValidationErrorType.MISSING_RECOMMENDED_FIELD);
+        expect(error.severity).toBe(ValidationErrorSeverity.WARNING);
+      }
+    });
   });
 
   describe('with inheritsTo properties', () => {

--- a/src/rules/core/recommended-fields-rule.js
+++ b/src/rules/core/recommended-fields-rule.js
@@ -32,7 +32,8 @@ module.exports = class RecommendedFieldsRule extends Rule {
       return [];
     }
     const errors = [];
-    for (const field of node.model.recommendedFields) {
+
+    for (const field of node.model.getRecommendedFields(node.options.validationMode)) {
       const testValue = node.getValueWithInheritance(field);
       const example = node.model.getRenderedExample(field);
       if (typeof testValue === 'undefined') {

--- a/src/rules/core/required-fields-rule.js
+++ b/src/rules/core/required-fields-rule.js
@@ -32,7 +32,8 @@ module.exports = class RequiredFieldsRule extends Rule {
       return [];
     }
     const errors = [];
-    for (const field of node.model.requiredFields) {
+
+    for (const field of node.model.getRequiredFields(node.options.validationMode)) {
       const testValue = node.getValueWithInheritance(field);
       const example = node.model.getRenderedExample(field);
       if (typeof testValue === 'undefined') {

--- a/src/rules/core/required-optional-fields-rule.js
+++ b/src/rules/core/required-optional-fields-rule.js
@@ -33,7 +33,8 @@ module.exports = class RequiredOptionalFieldsRule extends Rule {
       return [];
     }
     const errors = [];
-    for (const option of node.model.requiredOptions) {
+
+    for (const option of node.model.getRequiredOptions(node.options.validationMode)) {
       if (typeof (option.options) !== 'undefined'
           && option.options instanceof Array
       ) {


### PR DESCRIPTION
Update rules on requiredFields, recommendedFields and requiredOptions to use the definition specific to the current validationMode if there is one. Otherwise falls back on the default, top-level definition.

Part of https://github.com/openactive/data-models/issues/41