### PR TITLE
SW3: Timebox rule creation

### DIFF
--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -91,6 +91,15 @@ const Model = class {
     return fields || [];
   }
 
+  getShallNotIncludeFields(validationMode) {
+    const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
+    if (typeof specificImperativeConfiguration === 'object') {
+      const fields = specificImperativeConfiguration.shallNotInclude;
+      return fields || [];
+    }
+    return undefined; // there are no default shallNotInclude fields
+  }
+
   hasRecommendedField(field) {
     return PropertyHelper.arrayHasField(this.recommendedFields, field, this.version);
   }

--- a/src/rules/core/shall-not-include-fields-rule-spec.js
+++ b/src/rules/core/shall-not-include-fields-rule-spec.js
@@ -1,0 +1,88 @@
+const ShallNotIncludeFieldsRule = require('./shall-not-include-fields-rule');
+const Model = require('../../classes/model');
+const ModelNode = require('../../classes/model-node');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+const OptionsHelper = require('../../helpers/options');
+const ValidationMode = require('../../helpers/validation-mode');
+
+describe('ShallNotIncludeFieldsRule', () => {
+  const rule = new ShallNotIncludeFieldsRule();
+
+  const model = new Model({
+    type: 'Event',
+    validationMode: {
+      C1Request: 'request',
+    },
+    imperativeConfiguration: {
+      request: {
+        shallNotInclude: [
+          'duration',
+        ],
+      },
+    },
+    fields: {
+      remainigAttendeeCapacity: {
+        fieldName: 'remainingAttendeeCapacity',
+        requiredType: 'https://schema.org/Integer',
+      },
+    },
+  }, 'latest');
+
+  describe('when in a validation mode with shallNotInclude setting', () => {
+    const options = new OptionsHelper({ validationMode: ValidationMode.C1Request });
+
+    it('should return no error when no shall not include fields part of data', () => {
+      const data = {
+        type: 'Event',
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return no error when shall not include fields present in data', () => {
+      const data = {
+        type: 'Event',
+        duration: 1,
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+      expect(errors.length).toBe(1);
+      expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_ALLOWED_IN_SPEC);
+      expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+    });
+  });
+
+  describe('when no imperative config for validation mode', () => {
+    it('should not create errors', () => {
+      const data = {
+        type: 'Event',
+        duration: 1,
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+      );
+      const errors = rule.validate(nodeToTest);
+      expect(errors.length).toBe(0);
+    });
+  });
+});

--- a/src/rules/core/shall-not-include-fields-rule.js
+++ b/src/rules/core/shall-not-include-fields-rule.js
@@ -1,0 +1,45 @@
+const Rule = require('../rule');
+const PropertyHelper = require('../../helpers/property');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorCategory = require('../../errors/validation-error-category');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+module.exports = class ShallNotIncludeFieldsRule extends Rule {
+  constructor(options) {
+    super(options);
+    this.targetFields = '*';
+    this.meta = {
+      name: 'ShallNotIncludeFieldsRule',
+      description: 'Validates that fields that there are no fields that should not be included',
+      tests: {
+        default: {
+          message: 'Cannot include fields that are listed in the ShallNodeInclude specification for the given validation mode',
+          category: ValidationErrorCategory.CONFORMANCE,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.FIELD_NOT_ALLOWED_IN_SPEC,
+        },
+      },
+    };
+  }
+
+  validateField(node, field) {
+    const errors = [];
+
+    const shallNots = node.model.getShallNotIncludeFields(node.options.validationMode);
+    if (typeof shallNots !== 'undefined') {
+      if (PropertyHelper.arrayHasField(shallNots, field, node.model.version)) {
+        errors.push(
+          this.createError(
+            'default',
+            {
+              value: node.getValue(field),
+              path: node.getPath(field),
+            },
+          ),
+        );
+      }
+    }
+
+    return errors;
+  }
+};

--- a/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
@@ -3,7 +3,6 @@ const Model = require('../../classes/model');
 const ModelNode = require('../../classes/model-node');
 const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
-const OptionsHelper = require('../../helpers/options');
 
 describe('AvailableChannelForPrepaymentRule', () => {
   const rule = new AvailableChannelForPrepaymentRule();
@@ -13,11 +12,11 @@ describe('AvailableChannelForPrepaymentRule', () => {
     fields: {
       availableChannel: {
         fieldName: 'availableChannel',
-        requiredType: 'https://openactive.io/RequiredStatusType',
+        requiredType: 'ArrayOf#https://openactive.io/AvailableChannelType',
       },
       prepayment: {
         fieldName: 'prepayment',
-        requiredType: 'ArrayOf#https://openactive.io/AvailableChannelType',
+        requiredType: 'https://openactive.io/RequiredStatusType',
       },
     },
   }, 'latest');

--- a/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
@@ -1,0 +1,88 @@
+const AvailableChannelForPrepaymentRule = require('./available-channel-for-prepayment-rule');
+const Model = require('../../classes/model');
+const ModelNode = require('../../classes/model-node');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+const OptionsHelper = require('../../helpers/options');
+
+describe('AvailableChannelForPrepaymentRule', () => {
+  const rule = new AvailableChannelForPrepaymentRule();
+
+  const model = new Model({
+    type: 'Offer',
+    fields: {
+      availableChannel: {
+        fieldName: 'availableChannel',
+        requiredType: 'https://openactive.io/RequiredStatusType',
+      },
+      prepayment: {
+        fieldName: 'prepayment',
+        requiredType: 'ArrayOf#https://openactive.io/AvailableChannelType',
+      },
+    },
+  }, 'latest');
+
+  it('should target Offer model', () => {
+    const isTargeted = rule.isModelTargeted(model);
+    expect(isTargeted).toBe(true);
+  });
+
+  it('should return no error when payment is not set', () => {
+    const data = {
+      type: 'Offer',
+    };
+
+    const nodeToTest = new ModelNode(
+      '$',
+      data,
+      null,
+      model,
+    );
+    const errors = rule.validate(nodeToTest);
+    expect(errors.length).toBe(0);
+  });
+
+  const affectedPrepayments = ['https://openactive.io/Required', 'https://openactive.io/Optional'];
+  for (const prepayment of affectedPrepayments) {
+    describe(`when payment is ${prepayment}`, () => {
+      const validAvailableChannelsForPrepayment = ['https://openactive.io/OpenBookingPrepayment', 'https://openactive.io/TelephonePrepayment', 'https://openactive.io/OnlinePrepayment'];
+      for (const validChannel of validAvailableChannelsForPrepayment) {
+        it(`should return no error when availableChannel is set to ${validChannel}`, () => {
+          const data = {
+            type: 'Offer',
+            prepayment,
+            availableChannel: validChannel,
+          };
+
+          const nodeToTest = new ModelNode(
+            '$',
+            data,
+            null,
+            model,
+          );
+          const errors = rule.validate(nodeToTest);
+          expect(errors.length).toBe(0);
+        });
+      }
+
+      it('should return an error when availableChannel is not set to a valid value', () => {
+        const data = {
+          type: 'Offer',
+          prepayment,
+          availableChannel: '',
+        };
+
+        const nodeToTest = new ModelNode(
+          '$',
+          data,
+          null,
+          model,
+        );
+        const errors = rule.validate(nodeToTest);
+        expect(errors.length).toBe(1);
+        expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+        expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES);
+      });
+    });
+  }
+});

--- a/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
@@ -41,16 +41,18 @@ describe('AvailableChannelForPrepaymentRule', () => {
     expect(errors.length).toBe(0);
   });
 
+  const invalidChannel = 'https://openactive.io/Optional';
+
   const affectedPrepayments = ['https://openactive.io/Required', 'https://openactive.io/Optional'];
   for (const prepayment of affectedPrepayments) {
     describe(`when payment is ${prepayment}`, () => {
       const validAvailableChannelsForPrepayment = ['https://openactive.io/OpenBookingPrepayment', 'https://openactive.io/TelephonePrepayment', 'https://openactive.io/OnlinePrepayment'];
       for (const validChannel of validAvailableChannelsForPrepayment) {
-        it(`should return no error when availableChannel is set to ${validChannel}`, () => {
+        it(`should return no error when availableChannel contains ${validChannel}`, () => {
           const data = {
             type: 'Offer',
             prepayment,
-            availableChannel: validChannel,
+            availableChannel: [validChannel, invalidChannel],
           };
 
           const nodeToTest = new ModelNode(
@@ -64,11 +66,11 @@ describe('AvailableChannelForPrepaymentRule', () => {
         });
       }
 
-      it('should return an error when availableChannel is not set to a valid value', () => {
+      it('should return an error when availableChannel does not contain a valid value', () => {
         const data = {
           type: 'Offer',
           prepayment,
-          availableChannel: '',
+          availableChannel: [invalidChannel],
         };
 
         const nodeToTest = new ModelNode(

--- a/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule-spec.js
@@ -21,8 +21,8 @@ describe('AvailableChannelForPrepaymentRule', () => {
     },
   }, 'latest');
 
-  it('should target Offer model', () => {
-    const isTargeted = rule.isModelTargeted(model);
+  it('should target availableChannel field', () => {
+    const isTargeted = rule.isFieldTargeted(model, 'availableChannel');
     expect(isTargeted).toBe(true);
   });
 

--- a/src/rules/data-quality/available-channel-for-prepayment-rule.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule.js
@@ -1,0 +1,50 @@
+const Rule = require('../rule');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorCategory = require('../../errors/validation-error-category');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+module.exports = class AvailableChannelPrepaymentRule extends Rule {
+  constructor(options) {
+    super(options);
+    this.targetModels = ['Offer'];
+    this.meta = {
+      name: 'AvailableChannelPrepaymentRule',
+      description: 'Validates if oa:prepayment is https://openactive.io/Required or https://openactive.io/Optional, then oa:availableChannel must contain at least one of https://openactive.io/OpenBookingPrepayment, https://openactive.io/TelephonePrepayment or https://openactive.io/OnlinePrepayment',
+      tests: {
+        default: {
+          message: 'The `{{availableChannel}}` is not a valid available channel when prepayment is required or optional.',
+          category: ValidationErrorCategory.CONFORMANCE,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES,
+        },
+      },
+    };
+  }
+
+  validateModel(node) {
+    const errors = [];
+
+    const prepaymentValue = node.getValue('prepayment');
+
+    if (['https://openactive.io/Required', 'https://openactive.io/Optional'].includes(prepaymentValue)) {
+      const availableChannelValue = node.getValue('availableChannel');
+      const validAvailableChannelsForPrepayment = ['https://openactive.io/OpenBookingPrepayment', 'https://openactive.io/TelephonePrepayment', 'https://openactive.io/OnlinePrepayment'];
+      if (!validAvailableChannelsForPrepayment.includes(availableChannelValue)) {
+        errors.push(
+          this.createError(
+            'default',
+            {
+              value: availableChannelValue,
+              path: node.getPath('availableChannel'),
+            },
+            {
+              availableChannel: availableChannelValue,
+            },
+          ),
+        );
+      }
+    }
+
+    return errors;
+  }
+};

--- a/src/rules/data-quality/available-channel-for-prepayment-rule.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule.js
@@ -12,7 +12,7 @@ module.exports = class AvailableChannelPrepaymentRule extends Rule {
       description: 'Validates if oa:prepayment is https://openactive.io/Required or https://openactive.io/Optional, then oa:availableChannel must contain at least one of https://openactive.io/OpenBookingPrepayment, https://openactive.io/TelephonePrepayment or https://openactive.io/OnlinePrepayment',
       tests: {
         default: {
-          message: 'The `{{availableChannel}}` is not a valid available channel when prepayment is required or optional.',
+          message: 'The `{{availableChannel}}` does not contain a valid available channel when prepayment is required or optional.',
           category: ValidationErrorCategory.CONFORMANCE,
           severity: ValidationErrorSeverity.FAILURE,
           type: ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES,
@@ -25,20 +25,21 @@ module.exports = class AvailableChannelPrepaymentRule extends Rule {
     const errors = [];
 
     const prepaymentValue = node.getValue('prepayment');
+    const availableChannels = node.getValue(field);
 
     if (['https://openactive.io/Required', 'https://openactive.io/Optional'].includes(prepaymentValue)) {
-      const availableChannelValue = node.getValue('availableChannel');
-      const validAvailableChannelsForPrepayment = ['https://openactive.io/OpenBookingPrepayment', 'https://openactive.io/TelephonePrepayment', 'https://openactive.io/OnlinePrepayment'];
-      if (!validAvailableChannelsForPrepayment.includes(availableChannelValue)) {
+      const validAvailableChannels = ['https://openactive.io/OpenBookingPrepayment', 'https://openactive.io/TelephonePrepayment', 'https://openactive.io/OnlinePrepayment'];
+      const validAndPresentAvailableChannels = validAvailableChannels.filter(x => availableChannels.includes(x));
+      if (validAndPresentAvailableChannels.length === 0) {
         errors.push(
           this.createError(
             'default',
             {
-              value: availableChannelValue,
+              value: availableChannels,
               path: node.getPath('availableChannel'),
             },
             {
-              availableChannel: availableChannelValue,
+              availableChannel: availableChannels,
             },
           ),
         );

--- a/src/rules/data-quality/available-channel-for-prepayment-rule.js
+++ b/src/rules/data-quality/available-channel-for-prepayment-rule.js
@@ -6,7 +6,7 @@ const ValidationErrorSeverity = require('../../errors/validation-error-severity'
 module.exports = class AvailableChannelPrepaymentRule extends Rule {
   constructor(options) {
     super(options);
-    this.targetModels = ['Offer'];
+    this.targetFields = { Offer: 'availableChannel' };
     this.meta = {
       name: 'AvailableChannelPrepaymentRule',
       description: 'Validates if oa:prepayment is https://openactive.io/Required or https://openactive.io/Optional, then oa:availableChannel must contain at least one of https://openactive.io/OpenBookingPrepayment, https://openactive.io/TelephonePrepayment or https://openactive.io/OnlinePrepayment',
@@ -21,7 +21,7 @@ module.exports = class AvailableChannelPrepaymentRule extends Rule {
     };
   }
 
-  validateModel(node) {
+  validateField(node, field) {
     const errors = [];
 
     const prepaymentValue = node.getValue('prepayment');

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
@@ -3,6 +3,7 @@ const Model = require('../../classes/model');
 const ModelNode = require('../../classes/model-node');
 const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+const OptionsHelper = require('../../helpers/options');
 
 describe('EventRemainingAttendeeCapacityRule', () => {
   const rule = new EventRemainingAttendeeCapacityRule();
@@ -22,37 +23,55 @@ describe('EventRemainingAttendeeCapacityRule', () => {
     expect(isTargeted).toBe(true);
   });
 
-  it('should return no error when remainingAttendeeCapacity is > 0', () => {
-    const data = {
-      type: 'Event',
-      remainigAttendeeCapacity: 1,
-    };
+  for (const mode of ['C1', 'C2', 'B']) {
+    it(`should target booking mode ${mode}`, () => {
+      const isTargeted = rule.isModeTargeted(mode);
+      expect(isTargeted).toBe(true);
+    });
+  }
 
-    const nodeToTest = new ModelNode(
-      '$',
-      data,
-      null,
-      model,
-    );
-    const errors = rule.validate(nodeToTest);
-    expect(errors.length).toBe(0);
+  it('should not target opendata mode', () => {
+    const isTargeted = rule.isModeTargeted('opendata');
+    expect(isTargeted).toBe(false);
   });
 
-  it('should return no error when remainingAttendeeCapacity is < 0', () => {
-    const data = {
-      type: 'Event',
-      remainigAttendeeCapacity: -1,
-    };
+  describe('when in a booking mode like C1', () => {
+    const options = new OptionsHelper({ mode: 'C1' });
 
-    const nodeToTest = new ModelNode(
-      '$',
-      data,
-      null,
-      model,
-    );
-    const errors = rule.validate(nodeToTest);
-    expect(errors.length).toBe(1);
-    expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES);
-    expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+    it('should return no error when remainingAttendeeCapacity is > 0', () => {
+      const data = {
+        type: 'Event',
+        remainigAttendeeCapacity: 1,
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return no error when remainingAttendeeCapacity is < 0', () => {
+      const data = {
+        type: 'Event',
+        remainigAttendeeCapacity: -1,
+      };
+
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = rule.validate(nodeToTest);
+      expect(errors.length).toBe(1);
+      expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES);
+      expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+    });
   });
 });

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
@@ -4,6 +4,7 @@ const ModelNode = require('../../classes/model-node');
 const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
 const OptionsHelper = require('../../helpers/options');
+const ValidationMode = require('../../helpers/validation-mode');
 
 describe('EventRemainingAttendeeCapacityRule', () => {
   const rule = new EventRemainingAttendeeCapacityRule();
@@ -23,20 +24,20 @@ describe('EventRemainingAttendeeCapacityRule', () => {
     expect(isTargeted).toBe(true);
   });
 
-  for (const mode of ['C1', 'C2', 'B']) {
-    it(`should target booking mode ${mode}`, () => {
-      const isTargeted = rule.isModeTargeted(mode);
+  for (const mode of [ValidationMode.C1Request, ValidationMode.C1Response, ValidationMode.C2Request, ValidationMode.C2Response, ValidationMode.BRequest, ValidationMode.BResponse]) {
+    it(`should target booking validation mode ${mode}`, () => {
+      const isTargeted = rule.isValidationModeTargeted(mode);
       expect(isTargeted).toBe(true);
     });
   }
 
-  it('should not target opendata mode', () => {
-    const isTargeted = rule.isModeTargeted('opendata');
+  it('should not target OpenData validation mode', () => {
+    const isTargeted = rule.isValidationModeTargeted(ValidationMode.OpenData);
     expect(isTargeted).toBe(false);
   });
 
-  describe('when in a booking mode like C1', () => {
-    const options = new OptionsHelper({ mode: 'C1' });
+  describe('when in a booking mode like C1Request', () => {
+    const options = new OptionsHelper({ validationMode: ValidationMode.C1Request });
 
     it('should return no error when remainingAttendeeCapacity is > 0', () => {
       const data = {

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
@@ -1,0 +1,58 @@
+const EventRemainingAttendeeCapacityRule = require('./event-remaining-attendee-capacity-rule');
+const Model = require('../../classes/model');
+const ModelNode = require('../../classes/model-node');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+describe('EventRemainingAttendeeCapacityRule', () => {
+  const rule = new EventRemainingAttendeeCapacityRule();
+
+  const model = new Model({
+    type: 'Event',
+    fields: {
+      remainigAttendeeCapacity: {
+        fieldName: 'remainingAttendeeCapacity',
+        requiredType: 'https://schema.org/Integer',
+      },
+    },
+  }, 'latest');
+
+  it('should target remainigAttendeeCapacity fields', () => {
+    const isTargeted = rule.isFieldTargeted(model, 'remainigAttendeeCapacity');
+    expect(isTargeted).toBe(true);
+  });
+
+  it('should return no error when remainingAttendeeCapacity is > 0', () => {
+    const data = {
+      type: 'Event',
+      remainigAttendeeCapacity: 1,
+    };
+
+    const nodeToTest = new ModelNode(
+      '$',
+      data,
+      null,
+      model,
+    );
+    const errors = rule.validate(nodeToTest);
+    expect(errors.length).toBe(0);
+  });
+
+  it('should return no error when remainingAttendeeCapacity is < 0', () => {
+    const data = {
+      type: 'Event',
+      remainigAttendeeCapacity: -1,
+    };
+
+    const nodeToTest = new ModelNode(
+      '$',
+      data,
+      null,
+      model,
+    );
+    const errors = rule.validate(nodeToTest);
+    expect(errors.length).toBe(1);
+    expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES);
+    expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+  });
+});

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule-spec.js
@@ -24,16 +24,20 @@ describe('EventRemainingAttendeeCapacityRule', () => {
     expect(isTargeted).toBe(true);
   });
 
-  for (const mode of [ValidationMode.C1Request, ValidationMode.C1Response, ValidationMode.C2Request, ValidationMode.C2Response, ValidationMode.BRequest, ValidationMode.BResponse]) {
-    it(`should target booking validation mode ${mode}`, () => {
-      const isTargeted = rule.isValidationModeTargeted(mode);
-      expect(isTargeted).toBe(true);
-    });
-  }
+  describe('isValidationModeTargeted', () => {
+    const modesToTest = [ValidationMode.C1Request, ValidationMode.C1Response, ValidationMode.C2Request, ValidationMode.C2Response, ValidationMode.BRequest, ValidationMode.BResponse];
 
-  it('should not target OpenData validation mode', () => {
-    const isTargeted = rule.isValidationModeTargeted(ValidationMode.OpenData);
-    expect(isTargeted).toBe(false);
+    for (const mode of modesToTest) {
+      it(`should target ${mode}`, () => {
+        const isTargeted = rule.isValidationModeTargeted(mode);
+        expect(isTargeted).toBe(true);
+      });
+    }
+
+    it('should not target OpenData validation mode', () => {
+      const isTargeted = rule.isValidationModeTargeted(ValidationMode.OpenData);
+      expect(isTargeted).toBe(false);
+    });
   });
 
   describe('when in a booking mode like C1Request', () => {

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
@@ -2,12 +2,20 @@ const Rule = require('../rule');
 const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorCategory = require('../../errors/validation-error-category');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+const ValidationMode = require('../../helpers/validation-mode');
 
 module.exports = class EventRemainingAttendeeCapacityRule extends Rule {
   constructor(options) {
     super(options);
     this.targetFields = { Event: ['remainigAttendeeCapacity'] };
-    this.targetModes = ['C1', 'C2', 'B'];
+    this.targetValidationModes = [
+      ValidationMode.C1Request,
+      ValidationMode.C1Response,
+      ValidationMode.C2Request,
+      ValidationMode.C2Response,
+      ValidationMode.BRequest,
+      ValidationMode.BResponse,
+    ];
     this.meta = {
       name: 'EventRemainingAttendeeCapacityRule',
       description: 'Validates that the remainigAttendeeCapacity of an Event is greater than or equal to 0',

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
@@ -7,6 +7,7 @@ module.exports = class EventRemainingAttendeeCapacityRule extends Rule {
   constructor(options) {
     super(options);
     this.targetFields = { Event: ['remainigAttendeeCapacity'] };
+    this.targetModes = ['C1', 'C2', 'B'];
     this.meta = {
       name: 'EventRemainingAttendeeCapacityRule',
       description: 'Validates that the remainigAttendeeCapacity of an Event is greater than or equal to 0',

--- a/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
+++ b/src/rules/data-quality/event-remaining-attendee-capacity-rule.js
@@ -1,0 +1,43 @@
+const Rule = require('../rule');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorCategory = require('../../errors/validation-error-category');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+module.exports = class EventRemainingAttendeeCapacityRule extends Rule {
+  constructor(options) {
+    super(options);
+    this.targetFields = { Event: ['remainigAttendeeCapacity'] };
+    this.meta = {
+      name: 'EventRemainingAttendeeCapacityRule',
+      description: 'Validates that the remainigAttendeeCapacity of an Event is greater than or equal to 0',
+      tests: {
+        default: {
+          description: 'Raises a failure if the remainingAttendeeCapacity of an Event is not greater than or equal to 0',
+          message: 'The `remainingAttendeeCapacity` of an `Event` must be greater than or equal to 0.',
+          category: ValidationErrorCategory.DATA_QUALITY,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES,
+        },
+      },
+    };
+  }
+
+  validateField(node, field) {
+    const errors = [];
+
+    const fieldValue = node.getValue(field);
+
+    if (fieldValue < 0) {
+      errors.push(
+        this.createError(
+          'default',
+          {
+            path: node.getPath(field),
+          },
+        ),
+      );
+    }
+
+    return errors;
+  }
+};

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -51,6 +51,7 @@ module.exports = {
     require('./data-quality/session-series-schedule-type-rule'),
     require('./data-quality/currency-if-non-zero-price-rule'),
     require('./data-quality/if-needs-booking-must-have-valid-offer-rule'),
+    require('./data-quality/event-remaining-attendee-capacity-rule'),
 
     // Notes on the data consumer
     require('./consumer-notes/assume-no-gender-restriction-rule'),

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -10,6 +10,7 @@ module.exports = {
     require('./core/valid-model-type-rule'),
     require('./core/required-fields-rule'),
     require('./core/required-optional-fields-rule'),
+    require('./core/shall-not-include-fields-rule'),
     require('./core/fields-not-in-model-rule'),
     require('./core/fields-correct-type-rule'),
     require('./core/recommended-fields-rule'),
@@ -52,6 +53,7 @@ module.exports = {
     require('./data-quality/currency-if-non-zero-price-rule'),
     require('./data-quality/if-needs-booking-must-have-valid-offer-rule'),
     require('./data-quality/event-remaining-attendee-capacity-rule'),
+    require('./data-quality/available-channel-for-prepayment-rule'),
 
     // Notes on the data consumer
     require('./consumer-notes/assume-no-gender-restriction-rule'),


### PR DESCRIPTION
Rules added are: 
* One check of shallNotInclude as defined in https://github.com/openactive/data-models/issues/41 (wasn't included in #335 by accident)
* Event.remainingAttendeeCapacity must be equal to or greater than 0 (only for C1, C2, B)
* If oa:prepayment is https://openactive.io/Required or https://openactive.io/Optional, then oa:availableChannel must contain at least one of https://openactive.io/OpenBookingPrepayment, https://openactive.io/TelephonePrepayment or https://openactive.io/OnlinePrepayment

NB the shallNotInclude won't effect anything yet as no model specification yet includes validationModes or imperativeConfiguration attributes.