### PR TITLE
Handle unknown type when loading models based on fields of an ModelNode

### DIFF
--- a/src/classes/model-node.js
+++ b/src/classes/model-node.js
@@ -3,6 +3,7 @@ const Model = require('./model');
 const DataModelHelper = require('../helpers/data-model');
 const OptionsHelper = require('../helpers/options');
 const PropertyHelper = require('../helpers/property');
+const { InvalidModelNameError } = require('../exceptions');
 
 const ModelNode = class {
   constructor(name, value, parentNode, model, options, arrayIndex) {
@@ -156,8 +157,12 @@ const ModelNode = class {
             try {
               parentModel = DataModelHelper.loadModel(fieldValueType, this.options.version);
             } catch (e) {
-              // loading model can fail if fieldValueType is not the name of a valid model (e.g. typo or null or undefined)
-              parentModel = null;
+              if (e instanceof InvalidModelNameError) {
+                // no parent model if name is invalid
+                parentModel = null;
+              } else {
+                throw e;
+              }
             }
             if (parentModel) {
               const parentNode = new this.constructor(

--- a/src/classes/model-node.js
+++ b/src/classes/model-node.js
@@ -149,20 +149,26 @@ const ModelNode = class {
             && !(fieldValue instanceof Array)
             && fieldValue !== null
           ) {
+            // allow for data using @type instead of type
+            // because it's standard JSON-LD even in OA world expected to use the type shortcut
             const fieldValueType = (fieldValue.type || fieldValue['@type']);
-            if (fieldValueType !== undefined) {
-              const parentModel = DataModelHelper.loadModel(fieldValueType, this.options.version);
-              if (parentModel) {
-                const parentNode = new this.constructor(
-                  modelField.fieldName,
-                  fieldValue,
-                  this,
-                  new Model(parentModel),
-                  this.options,
-                );
-                if (this.canInheritFrom(parentNode)) {
-                  return parentNode;
-                }
+            let parentModel;
+            try {
+              parentModel = DataModelHelper.loadModel(fieldValueType, this.options.version);
+            } catch (e) {
+              // loading model can fail if fieldValueType is not the name of a valid model (e.g. typo or null or undefined)
+              parentModel = null;
+            }
+            if (parentModel) {
+              const parentNode = new this.constructor(
+                modelField.fieldName,
+                fieldValue,
+                this,
+                new Model(parentModel),
+                this.options,
+              );
+              if (this.canInheritFrom(parentNode)) {
+                return parentNode;
               }
             }
           }

--- a/src/classes/model-node.js
+++ b/src/classes/model-node.js
@@ -149,17 +149,20 @@ const ModelNode = class {
             && !(fieldValue instanceof Array)
             && fieldValue !== null
           ) {
-            const parentModel = DataModelHelper.loadModel(fieldValue.type, this.options.version);
-            if (parentModel) {
-              const parentNode = new this.constructor(
-                modelField.fieldName,
-                fieldValue,
-                this,
-                new Model(parentModel),
-                this.options,
-              );
-              if (this.canInheritFrom(parentNode)) {
-                return parentNode;
+            const fieldValueType = (fieldValue.type || fieldValue['@type']);
+            if (fieldValueType !== undefined) {
+              const parentModel = DataModelHelper.loadModel(fieldValueType, this.options.version);
+              if (parentModel) {
+                const parentNode = new this.constructor(
+                  modelField.fieldName,
+                  fieldValue,
+                  this,
+                  new Model(parentModel),
+                  this.options,
+                );
+                if (this.canInheritFrom(parentNode)) {
+                  return parentNode;
+                }
               }
             }
           }

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -1,0 +1,5 @@
+class InvalidModelNameError extends Error {}
+
+module.exports = {
+  InvalidModelNameError,
+};

--- a/src/helpers/data-model.js
+++ b/src/helpers/data-model.js
@@ -8,6 +8,8 @@ const {
   loadModel,
 } = require('@openactive/data-models');
 
+const { InvalidModelNameError } = require('../exceptions');
+
 const DataModelHelper = class {
   static getContext(version) {
     if (typeof version === 'undefined') {
@@ -59,12 +61,20 @@ const DataModelHelper = class {
 
   static loadModel(name, version) {
     if (typeof name === 'undefined') {
-      throw Error('Parameter "name" must be defined');
+      throw new InvalidModelNameError('Parameter "name" must be defined');
     }
     if (typeof version === 'undefined') {
       throw Error('Parameter "version" must be defined');
     }
-    return loadModel(name, version);
+    try {
+      return loadModel(name, version);
+    } catch (e) {
+      if (e.message.startsWith('Invalid model name')) {
+        throw new InvalidModelNameError('Parameter "name" must be a valid model name');
+      } else {
+        throw e;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
ModelNode.getInheritNode was throwing an error if when trying to load models based on fields on the model-node if the type property of a field was invalid (perhaps because it was missing type or was using @type and was not the name of a model).

Instead catch an errors in loading the model and skip that bad field (and also allow for @type since this is core to JSON-LD even if OA validator expects the use of the type alias).

The main purpose is to prevent the validation to completely fail when RequiredFieldsRule tries to check the presence of a required field that is missing from a model instance so it tries to check for its presence on certain other fields of the model instance. Example data that can break the Validator UI is found below - note the use of @type in superEvent which is causing problems when the rule tries to find the expected startDate field and so seems to go looking for it on the superEvent (which was raising an error because it couldn't find a type to load for the superEvent since it's @type).
```json
{
  "@context": "https://openactive.io/",
  "@type": "ScheduledSession",
  "superEvent": {
    "@type": "SessionSeries"
  }
}
```