### PR TITLE
Validate context specific imperative configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@openactive/data-models": "^2.0.43",
+    "@openactive/data-models": "^2.0.64",
     "axios": "^0.18.0",
     "currency-codes": "^1.5.1",
     "jsonpath": "^1.0.2",

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -45,24 +45,42 @@ const Model = class {
   }
 
   getImperativeConfiguration(validationMode) {
-    if (
-      typeof this.validationMode === 'object'
-      && typeof this.validationMode[validationMode] === 'string'
-    ) {
-      return this.imperativeConfiguration[this.validationMode[validationMode]];
-    }
-    return undefined;
+    if (!this.validationMode) return undefined;
+    if (!this.imperativeConfiguration) return undefined;
+
+    const imperativeConfigName = this.validationMode[validationMode];
+
+    if (!imperativeConfigName) return undefined;
+
+    return this.imperativeConfiguration[imperativeConfigName];
   }
 
-  getRequiredFields(validationMode) {
-    let fields;
+  getImperativeConfigurationWithContext(validationMode, containingFieldName) {
+    if (!this.validationMode) return undefined;
+    if (!this.imperativeConfigurationWithContext) return undefined;
+
+    const contextualImperativeConfigName = this.validationMode[validationMode];
+
+    if (!contextualImperativeConfigName) return undefined;
+
+    const contextualImperativeConfigs = this.imperativeConfigurationWithContext[contextualImperativeConfigName];
+
+    if (!contextualImperativeConfigs) return undefined;
+
+    const contextualImperativeConfig = contextualImperativeConfigs[containingFieldName];
+
+    return contextualImperativeConfig;
+  }
+
+  getRequiredFields(validationMode, containingFieldName) {
+    const specificContextualImperativeConfiguration = this.getImperativeConfigurationWithContext(validationMode, containingFieldName);
     const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
-    if (typeof specificImperativeConfiguration === 'object') {
-      fields = specificImperativeConfiguration.requiredFields;
-    } else {
-      fields = this.data.requiredFields;
-    }
-    return fields || [];
+
+    if (specificContextualImperativeConfiguration && specificContextualImperativeConfiguration.requiredFields) return specificContextualImperativeConfiguration.requiredFields;
+
+    if (specificImperativeConfiguration && specificImperativeConfiguration.requiredFields) return specificImperativeConfiguration.requiredFields;
+
+    return this.data.requiredFields || [];
   }
 
   hasRequiredField(field) {
@@ -161,6 +179,10 @@ const Model = class {
 
   get imperativeConfiguration() {
     return this.data.imperativeConfiguration;
+  }
+
+  get imperativeConfigurationWithContext() {
+    return this.data.imperativeConfigurationWithContext;
   }
 };
 

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -98,15 +98,15 @@ const Model = class {
     return options || [];
   }
 
-  getRecommendedFields(validationMode) {
-    let fields;
+  getRecommendedFields(validationMode, containingFieldName) {
+    const specificContextualImperativeConfiguration = this.getImperativeConfigurationWithContext(validationMode, containingFieldName);
     const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
-    if (typeof specificImperativeConfiguration === 'object') {
-      fields = specificImperativeConfiguration.recommendedFields;
-    } else {
-      fields = this.data.recommendedFields;
-    }
-    return fields || [];
+
+    if (specificContextualImperativeConfiguration && specificContextualImperativeConfiguration.recommendedFields) return specificContextualImperativeConfiguration.recommendedFields;
+
+    if (specificImperativeConfiguration && specificImperativeConfiguration.recommendedFields) return specificImperativeConfiguration.recommendedFields;
+
+    return this.data.recommendedFields || [];
   }
 
   getShallNotIncludeFields(validationMode) {

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -87,15 +87,15 @@ const Model = class {
     return PropertyHelper.arrayHasField(this.requiredFields, field, this.version);
   }
 
-  getRequiredOptions(validationMode) {
-    let options;
+  getRequiredOptions(validationMode, containingFieldName) {
+    const specificContextualImperativeConfiguration = this.getImperativeConfigurationWithContext(validationMode, containingFieldName);
     const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
-    if (typeof specificImperativeConfiguration === 'object') {
-      options = specificImperativeConfiguration.requiredOptions;
-    } else {
-      options = this.data.requiredOptions;
-    }
-    return options || [];
+
+    if (specificContextualImperativeConfiguration && specificContextualImperativeConfiguration.requiredOptions) return specificContextualImperativeConfiguration.requiredOptions;
+
+    if (specificImperativeConfiguration && specificImperativeConfiguration.requiredOptions) return specificImperativeConfiguration.requiredOptions;
+
+    return this.data.requiredOptions || [];
   }
 
   getRecommendedFields(validationMode, containingFieldName) {

--- a/src/classes/model.js
+++ b/src/classes/model.js
@@ -109,12 +109,14 @@ const Model = class {
     return this.data.recommendedFields || [];
   }
 
-  getShallNotIncludeFields(validationMode) {
+  getShallNotIncludeFields(validationMode, containingFieldName) {
+    const specificContextualImperativeConfiguration = this.getImperativeConfigurationWithContext(validationMode, containingFieldName);
     const specificImperativeConfiguration = this.getImperativeConfiguration(validationMode);
-    if (typeof specificImperativeConfiguration === 'object') {
-      const fields = specificImperativeConfiguration.shallNotInclude;
-      return fields || [];
-    }
+
+    if (specificContextualImperativeConfiguration && specificContextualImperativeConfiguration.shallNotInclude) return specificContextualImperativeConfiguration.shallNotInclude;
+
+    if (specificImperativeConfiguration && specificImperativeConfiguration.shallNotInclude) return specificImperativeConfiguration.shallNotInclude;
+
     return undefined; // there are no default shallNotInclude fields
   }
 

--- a/src/rules/core/recommended-fields-rule-spec.js
+++ b/src/rules/core/recommended-fields-rule-spec.js
@@ -14,12 +14,27 @@ describe('RecommendedFieldsRule', () => {
     ],
     validationMode: {
       C1Request: 'request',
+      C1Response: 'response',
     },
     imperativeConfiguration: {
       request: {
         recommendedFields: [
           'duration',
         ],
+      },
+    },
+    imperativeConfigurationWithContext: {
+      response: {
+        wedding: {
+          recommendedFields: [
+            'barTab',
+          ],
+        },
+        dinner: {
+          recommendedFields: [
+            'dressCode',
+          ],
+        },
       },
     },
   }, 'latest');
@@ -104,7 +119,7 @@ describe('RecommendedFieldsRule', () => {
   describe('when validation mode is on with separate required fields', () => {
     const options = new OptionsHelper({ validationMode: 'C1Request' });
 
-    it('should return no errors if all required fields are present', async () => {
+    it('should return no errors if all recommended fields are present', async () => {
       const data = {
         type: 'Event',
         duration: 'PT1H30M',
@@ -122,13 +137,57 @@ describe('RecommendedFieldsRule', () => {
       expect(errors.length).toBe(0);
     });
 
-    it('should return a warning per field if any required fields are missing', async () => {
+    it('should return a warning per field if any recommended fields are missing', async () => {
       const data = {
         type: 'Event',
       };
 
       const nodeToTest = new ModelNode(
         '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(1);
+
+      for (const error of errors) {
+        expect(error.type).toBe(ValidationErrorType.MISSING_RECOMMENDED_FIELD);
+        expect(error.severity).toBe(ValidationErrorSeverity.WARNING);
+      }
+    });
+  });
+
+  describe('when there is a context-specific imperative config', () => {
+    const options = new OptionsHelper({ validationMode: 'C1Response' });
+
+    it('should return no errors if all recommended fields are present', async () => {
+      const data = {
+        type: 'Event',
+        barTab: 300,
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return a warning per field if any recommended fields are missing', async () => {
+      const data = {
+        type: 'Event',
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
         data,
         null,
         model,

--- a/src/rules/core/recommended-fields-rule.js
+++ b/src/rules/core/recommended-fields-rule.js
@@ -33,7 +33,9 @@ module.exports = class RecommendedFieldsRule extends Rule {
     }
     const errors = [];
 
-    for (const field of node.model.getRecommendedFields(node.options.validationMode)) {
+
+    const recommendedFields = node.model.getRecommendedFields(node.options.validationMode, node.name);
+    for (const field of recommendedFields) {
       const testValue = node.getValueWithInheritance(field);
       const example = node.model.getRenderedExample(field);
       if (typeof testValue === 'undefined') {

--- a/src/rules/core/required-fields-rule-spec.js
+++ b/src/rules/core/required-fields-rule-spec.js
@@ -15,12 +15,27 @@ describe('RequiredFieldsRule', () => {
     ],
     validationMode: {
       C1Request: 'request',
+      C1Response: 'response',
     },
     imperativeConfiguration: {
       request: {
         requiredFields: [
           'duration',
         ],
+      },
+    },
+    imperativeConfigurationWithContext: {
+      response: {
+        wedding: {
+          requiredFields: [
+            'barTab',
+          ],
+        },
+        dinner: {
+          requiredFields: [
+            'dressCode',
+          ],
+        },
       },
     },
   }, 'latest');
@@ -154,6 +169,52 @@ describe('RequiredFieldsRule', () => {
 
       const nodeToTest = new ModelNode(
         '$',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(1);
+
+      for (const error of errors) {
+        expect(error.type).toBe(ValidationErrorType.MISSING_REQUIRED_FIELD);
+        expect(error.severity).toBe(ValidationErrorSeverity.FAILURE);
+      }
+    });
+  });
+
+  describe('when there is a context-specific imperative config', () => {
+    const options = new OptionsHelper({ validationMode: 'C1Response' });
+
+    it('should return no errors if all required fields are present', async () => {
+      const data = {
+        type: 'Event',
+        barTab: 300,
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return a failure per field if any required fields are missing', async () => {
+      const data = {
+        '@context': 'https://openactive.io/',
+        type: 'Event',
+        dressCode: 'blacktie',
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
         data,
         null,
         model,

--- a/src/rules/core/required-fields-rule.js
+++ b/src/rules/core/required-fields-rule.js
@@ -32,8 +32,8 @@ module.exports = class RequiredFieldsRule extends Rule {
       return [];
     }
     const errors = [];
-
-    for (const field of node.model.getRequiredFields(node.options.validationMode)) {
+    const requiredFields = node.model.getRequiredFields(node.options.validationMode, node.name);
+    for (const field of requiredFields) {
       const testValue = node.getValueWithInheritance(field);
       const example = node.model.getRenderedExample(field);
       if (typeof testValue === 'undefined') {

--- a/src/rules/core/required-optional-fields-rule-spec.js
+++ b/src/rules/core/required-optional-fields-rule-spec.js
@@ -21,6 +21,7 @@ describe('RequiredOptionalFieldsRule', () => {
     ],
     validationMode: {
       C1Request: 'request',
+      C1Response: 'response',
     },
     imperativeConfiguration: {
       request: {
@@ -32,6 +33,30 @@ describe('RequiredOptionalFieldsRule', () => {
             ],
           },
         ],
+      },
+    },
+    imperativeConfigurationWithContext: {
+      response: {
+        wedding: {
+          requiredOptions: [
+            {
+              options: [
+                'church',
+                'registerOffice',
+              ],
+            },
+          ],
+        },
+        dinner: {
+          requiredOptions: [
+            {
+              options: [
+                'starter',
+                'pudding',
+              ],
+            },
+          ],
+        },
       },
     },
   }, 'latest');
@@ -177,6 +202,49 @@ describe('RequiredOptionalFieldsRule', () => {
       expect(errors[0].type).toBe(ValidationErrorType.MISSING_REQUIRED_FIELD);
       expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
       expect(errors[0].path).toBe('$["duration","endDate"]');
+    });
+  });
+
+  describe('when there is a context-specific imperative config', () => {
+    const options = new OptionsHelper({ validationMode: 'C1Response' });
+
+    it('should return no errors if required optional fields are present', async () => {
+      const data = {
+        type: 'Event',
+        church: 'Holy Trinity',
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return a failure per option group if any required optional fields are missing', async () => {
+      const data = {
+        type: 'Event',
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(1);
+
+      expect(errors[0].type).toBe(ValidationErrorType.MISSING_REQUIRED_FIELD);
+      expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+      expect(errors[0].path).toBe('$.wedding["church","registerOffice"]');
     });
   });
 

--- a/src/rules/core/required-optional-fields-rule.js
+++ b/src/rules/core/required-optional-fields-rule.js
@@ -33,8 +33,8 @@ module.exports = class RequiredOptionalFieldsRule extends Rule {
       return [];
     }
     const errors = [];
-
-    for (const option of node.model.getRequiredOptions(node.options.validationMode)) {
+    const requiredOptions = node.model.getRequiredOptions(node.options.validationMode, node.name);
+    for (const option of requiredOptions) {
       if (typeof (option.options) !== 'undefined'
           && option.options instanceof Array
       ) {

--- a/src/rules/core/shall-not-include-fields-rule-spec.js
+++ b/src/rules/core/shall-not-include-fields-rule-spec.js
@@ -12,12 +12,27 @@ describe('ShallNotIncludeFieldsRule', () => {
     type: 'Event',
     validationMode: {
       C1Request: 'request',
+      C1Response: 'response',
     },
     imperativeConfiguration: {
       request: {
         shallNotInclude: [
           'duration',
         ],
+      },
+    },
+    imperativeConfigurationWithContext: {
+      response: {
+        wedding: {
+          shallNotInclude: [
+            'price',
+          ],
+        },
+        dinner: {
+          shallNotInclude: [
+            'barTab',
+          ],
+        },
       },
     },
     fields: {
@@ -47,7 +62,7 @@ describe('ShallNotIncludeFieldsRule', () => {
       expect(errors.length).toBe(0);
     });
 
-    it('should return no error when shall not include fields present in data', async () => {
+    it('should return failures when shall not include fields present in data', async () => {
       const data = {
         type: 'Event',
         duration: 1,
@@ -61,6 +76,47 @@ describe('ShallNotIncludeFieldsRule', () => {
         options,
       );
       const errors = await rule.validate(nodeToTest);
+      expect(errors.length).toBe(1);
+      expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_ALLOWED_IN_SPEC);
+      expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+    });
+  });
+
+  describe('when there is a context-specific imperative config', () => {
+    const options = new OptionsHelper({ validationMode: 'C1Response' });
+
+    it('should return no error when shall not include fields present in data', async () => {
+      const data = {
+        type: 'Event',
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('should return failures when shall not include fields present in data', async () => {
+      const data = {
+        type: 'Event',
+        price: 10000,
+      };
+
+      const nodeToTest = new ModelNode(
+        'wedding',
+        data,
+        null,
+        model,
+        options,
+      );
+      const errors = await rule.validate(nodeToTest);
+
       expect(errors.length).toBe(1);
       expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_ALLOWED_IN_SPEC);
       expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);

--- a/src/rules/core/shall-not-include-fields-rule.js
+++ b/src/rules/core/shall-not-include-fields-rule.js
@@ -29,7 +29,7 @@ module.exports = class ShallNotIncludeFieldsRule extends Rule {
   validateField(node, field) {
     const errors = [];
 
-    const shallNots = node.model.getShallNotIncludeFields(node.options.validationMode);
+    const shallNots = node.model.getShallNotIncludeFields(node.options.validationMode, node.name);
     if (typeof shallNots !== 'undefined') {
       if (PropertyHelper.arrayHasField(shallNots, field, node.model.version)) {
         errors.push(


### PR DESCRIPTION
Adds checks based on imperativeConfigWithContext where the validation mode and the name of the fielding holding the data determine which field must/should/cannot be included - https://github.com/openactive/openactive-test-suite/issues/16

It first tries to find a validation-mode-and-context-specific version, then a validation-mode specific version before falling back on the model defaults.

NB relies on https://github.com/openactive/data-models/pull/51