### PR TITLE
Add rules to specifically check the startDate and endDate of ScheduledSessions

### DIFF
--- a/src/rules/format/scheduled-session-datetime-format-rule-spec.js
+++ b/src/rules/format/scheduled-session-datetime-format-rule-spec.js
@@ -36,6 +36,7 @@ describe('ScheduledSessionDatetimeFormatRule', () => {
     model.hasSpecification = true;
     const values = [
       '2017-09-06T09:00:00Z',
+      '2018-08-01T10:51:02+01:00',
     ];
 
     for (const value of values) {

--- a/src/rules/format/scheduled-session-datetime-format-rule-spec.js
+++ b/src/rules/format/scheduled-session-datetime-format-rule-spec.js
@@ -1,0 +1,84 @@
+const ScheduledSessionDatetimeFormatRule = require('./scheduled-session-datetime-format-rule');
+const Model = require('../../classes/model');
+const ModelNode = require('../../classes/model-node');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+describe('ScheduledSessionDatetimeFormatRule', () => {
+  let model;
+  let rule;
+
+  beforeEach(() => {
+    model = new Model({
+      type: 'ScheduledSession',
+      fields: {
+        startDate: {
+          fieldName: 'startDate',
+          requiredType: 'https://schema.org/DateTime',
+        },
+        endDate: {
+          fieldName: 'endDate',
+          requiredType: 'https://schema.org/DateTime',
+        },
+      },
+    }, 'latest');
+    rule = new ScheduledSessionDatetimeFormatRule();
+  });
+
+  it('should target ScheduledSession startDate', () => {
+    const isTargetedStartDate = rule.isFieldTargeted(model, 'startDate');
+    expect(isTargetedStartDate).toBe(true);
+    const isTargetedEndDate = rule.isFieldTargeted(model, 'endDate');
+    expect(isTargetedEndDate).toBe(true);
+  });
+
+  it('should not return an error for a valid datetime', async () => {
+    model.hasSpecification = true;
+    const values = [
+      '2017-09-06T09:00:00Z',
+    ];
+
+    for (const value of values) {
+      const data = {
+        'schema:startDate': value,
+        'schema:endDate': value,
+      };
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+      );
+      const errors = await rule.validate(nodeToTest);
+      expect(errors.length).toBe(0);
+    }
+  });
+
+  it('should return an error for an invalid datetime', async () => {
+    model.hasSpecification = true;
+    const values = [
+      '2017-09-06T09:00:00',
+      '2018-10-17',
+      'ABC',
+    ];
+
+    for (const value of values) {
+      const data = {
+        'schema:startDate': value,
+        'schema:endDate': value,
+      };
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        model,
+      );
+      const errors = await rule.validate(nodeToTest);
+      expect(errors.length).toBe(2);
+      expect(errors[0].type).toBe(ValidationErrorType.INVALID_FORMAT);
+      expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+      expect(errors[1].type).toBe(ValidationErrorType.INVALID_FORMAT);
+      expect(errors[1].severity).toBe(ValidationErrorSeverity.FAILURE);
+    }
+  });
+});

--- a/src/rules/format/scheduled-session-datetime-format-rule.js
+++ b/src/rules/format/scheduled-session-datetime-format-rule.js
@@ -1,0 +1,60 @@
+const moment = require('moment');
+const Rule = require('../rule');
+const ValidationErrorType = require('../../errors/validation-error-type');
+const ValidationErrorCategory = require('../../errors/validation-error-category');
+const ValidationErrorSeverity = require('../../errors/validation-error-severity');
+
+module.exports = class ScheduledSessionDatetimeFormatRule extends Rule {
+  constructor(options) {
+    super(options);
+    this.targetFields = {
+      ScheduledSession: [
+        'startDate',
+        'endDate',
+      ],
+    };
+    this.meta = {
+      name: 'ScheduledSessionDatetimeFormatRule',
+      description: 'Validates that a ScheduledSession has a startDate and endDate in the correct format.',
+      tests: {
+        startDate: {
+          description: 'Raises a failure if a ScheduledSession startDate is in the incorrect format.',
+          message: 'startDate Datetime must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
+          category: ValidationErrorCategory.CONFORMANCE,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.INVALID_FORMAT,
+        },
+        endDate: {
+          description: 'Raises a failure if a ScheduledSession endDate is in the incorrect format.',
+          message: 'endDate Datetime must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
+          category: ValidationErrorCategory.CONFORMANCE,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.INVALID_FORMAT,
+        },
+      },
+    };
+  }
+
+  validateField(node, field) {
+    const fieldObj = node.model.getField(field);
+    if (typeof fieldObj === 'undefined') {
+      return [];
+    }
+    const fieldValue = node.getValue(field);
+    const errors = [];
+    const DatetimeValue = moment(fieldValue, ['YYYY-MM-DD\\THH:mm:ssZZ'], true);
+
+    if (!DatetimeValue.isValid()) {
+      errors.push(
+        this.createError(
+          fieldObj.fieldName,
+          {
+            value: fieldValue,
+            path: node.getPath(field),
+          },
+        ),
+      );
+    }
+    return errors;
+  }
+};

--- a/src/rules/format/scheduled-session-datetime-format-rule.js
+++ b/src/rules/format/scheduled-session-datetime-format-rule.js
@@ -19,14 +19,14 @@ module.exports = class ScheduledSessionDatetimeFormatRule extends Rule {
       tests: {
         startDate: {
           description: 'Raises a failure if a ScheduledSession startDate is in the incorrect format.',
-          message: 'startDate Datetime must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
+          message: 'ScheduledSession startDate must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
           category: ValidationErrorCategory.CONFORMANCE,
           severity: ValidationErrorSeverity.FAILURE,
           type: ValidationErrorType.INVALID_FORMAT,
         },
         endDate: {
           description: 'Raises a failure if a ScheduledSession endDate is in the incorrect format.',
-          message: 'endDate Datetime must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
+          message: 'ScheduledSession endDate must be expressed as ISO 8601 format datetimes with a trailing definition of timezone. For example, `"2018-08-01T10:51:02Z"` or `"2018-08-01T10:51:02+01:00"`.\n\nFor more information, see [the specification](https://www.w3.org/2017/08/realtime-paged-data-exchange/#date-and-time-formats).',
           category: ValidationErrorCategory.CONFORMANCE,
           severity: ValidationErrorSeverity.FAILURE,
           type: ValidationErrorType.INVALID_FORMAT,


### PR DESCRIPTION
# #323

Ensure that the startDate and endDate for ScheduledSessions are of the required format. 