### PR TITLE
rules: data-quality: Extend priceCurrency to additional models

### DIFF
--- a/src/rules/data-quality/currency-if-non-zero-price-rule-spec.js
+++ b/src/rules/data-quality/currency-if-non-zero-price-rule-spec.js
@@ -5,64 +5,140 @@ const ValidationErrorType = require('../../errors/validation-error-type');
 const ValidationErrorSeverity = require('../../errors/validation-error-severity');
 
 describe('CurrencyIfNonZeroPriceRule', () => {
-  let model;
+  let models;
   let rule;
 
   beforeEach(() => {
-    model = new Model({
-      type: 'Offer',
-      inSpec: [
-        'price',
-        'priceCurrency',
-      ],
-    }, 'latest');
+    models = {
+      Offer: new Model({
+        type: 'Offer',
+        inSpec: [
+          'price',
+          'priceCurrency',
+        ],
+      }, 'latest'),
+      OfferOverride: new Model({
+        type: 'OfferOverride',
+        inSpec: [
+          'price',
+          'priceCurrency',
+        ],
+      }, 'latest'),
+      TaxChargeSpecification: new Model({
+        type: 'TaxChargeSpecification',
+        inSpec: [
+          'price',
+          'priceCurrency',
+        ],
+      }, 'latest'),
+      PriceSpecification: new Model({
+        type: 'PriceSpecification',
+        inSpec: [
+          'price',
+          'priceCurrency',
+        ],
+      }, 'latest'),
+    };
     rule = new CurrencyIfNonZeroPriceRule();
   });
 
   it('should target Offer models', () => {
-    const isTargeted = rule.isModelTargeted(model);
+    let isTargeted = rule.isModelTargeted(models.Offer);
+    expect(isTargeted).toBe(true);
+    isTargeted = rule.isModelTargeted(models.OfferOverride);
+    expect(isTargeted).toBe(true);
+    isTargeted = rule.isModelTargeted(models.TaxChargeSpecification);
+    expect(isTargeted).toBe(true);
+    isTargeted = rule.isModelTargeted(models.PriceSpecification);
     expect(isTargeted).toBe(true);
   });
 
   it('should return no errors if the Offer has a price of zero', async () => {
-    const data = {
-      '@type': 'Offer',
-      price: 0,
-    };
+    const dataItems = [
+      {
+        '@type': 'Offer',
+        price: 0,
+      },
+      {
+        '@type': 'OfferOverride',
+        price: 0,
+      },
+      {
+        '@type': 'TaxChargeSpecification',
+        price: 0,
+      },
+      {
+        '@type': 'PriceSpecification',
+        price: 0,
+      },
+    ];
 
-    const nodeToTest = new ModelNode(
-      '$',
-      data,
-      null,
-      model,
-    );
-    const errors = await rule.validate(nodeToTest);
+    for (const data of dataItems) {
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        models[data['@type']],
+      );
+      const errors = await rule.validate(nodeToTest);
 
-    expect(errors.length).toBe(0);
+      expect(errors.length).toBe(0);
+    }
   });
 
   it('should return no errors if the Offer has a non-zero price, but has a currency set', async () => {
-    const data = {
-      '@type': 'Offer',
-      price: 5,
-      priceCurrency: 'GBP',
-    };
+    const dataItems = [
+      {
+        '@type': 'Offer',
+        price: 0,
+        priceCurrency: 'GBP',
+      },
+      {
+        '@type': 'OfferOverride',
+        price: 0,
+        priceCurrency: 'GBP',
+      },
+      {
+        '@type': 'TaxChargeSpecification',
+        price: 0,
+        priceCurrency: 'GBP',
+      },
+      {
+        '@type': 'PriceSpecification',
+        price: 0,
+        priceCurrency: 'GBP',
+      },
+    ];
 
-    const nodeToTest = new ModelNode(
-      '$',
-      data,
-      null,
-      model,
-    );
-    const errors = await rule.validate(nodeToTest);
+    for (const data of dataItems) {
+      const nodeToTest = new ModelNode(
+        '$',
+        data,
+        null,
+        models[data['@type']],
+      );
+      const errors = await rule.validate(nodeToTest);
 
-    expect(errors.length).toBe(0);
+      expect(errors.length).toBe(0);
+    }
   });
 
   it('should return an error if the Offer has a non-zero price, and has no currency set', async () => {
     const dataItems = [
       {
         '@type': 'Offer',
+        price: 5,
+      },
+      {
+        '@type': 'OfferOverride',
+        price: 5,
+      },
+      {
+        '@type': 'TaxChargeSpecification',
+        price: 5,
+      },
+      {
+        '@type': 'PriceSpecification',
         price: 5,
       },
     ];
@@ -72,7 +148,7 @@ describe('CurrencyIfNonZeroPriceRule', () => {
         '$',
         data,
         null,
-        model,
+        models[data['@type']],
       );
       const errors = await rule.validate(nodeToTest);
 

--- a/src/rules/data-quality/currency-if-non-zero-price-rule.js
+++ b/src/rules/data-quality/currency-if-non-zero-price-rule.js
@@ -6,7 +6,7 @@ const ValidationErrorSeverity = require('../../errors/validation-error-severity'
 module.exports = class CurrencyIfNonZeroPriceRule extends Rule {
   constructor(options) {
     super(options);
-    this.targetModels = ['Offer'];
+    this.targetModels = ['TaxChargeSpecification', 'PriceSpecification', 'Offer', 'OfferOverride'];
     this.meta = {
       name: 'CurrencyIfNonZeroPriceRule',
       description: 'Validates that a priceCurrency is set if an Offer\'s price is non-zero.',


### PR DESCRIPTION
# #306 

This rule has been extended to models including TaxChargeSpecification, PriceSpecification, and OfferOverride.

From a little testing it looked like this was already working as described for the `Offer` model, but not the other 3 described above. I believe this will extend it to cover those models?