### PR TITLE
rules: core: Update value-in-options rule to capture invalid arrays

### DIFF
--- a/src/rules/core/value-in-options-rule-spec.js
+++ b/src/rules/core/value-in-options-rule-spec.js
@@ -40,6 +40,15 @@ describe('ValueInOptionsRule', () => {
           'HEAD',
         ],
       },
+      genderRestriction: {
+        fieldName: 'genderRestriction',
+        requiredType: 'https://schema.org/Text',
+        options: [
+          'https://openactive.io/NoRestriction',
+          'https://openactive.io/MaleOnly',
+          'https://openactive.io/FemaleOnly',
+        ],
+      },
     },
   }, 'latest');
   model.hasSpecification = true;
@@ -233,6 +242,30 @@ describe('ValueInOptionsRule', () => {
     expect(errors.length).toBe(1);
 
     expect(errors[0].type).toBe(ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES);
+    expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
+  });
+
+  it('should return a different error message if the field value is an array', async () => {
+    const data = {
+      '@type': 'Offer',
+      genderRestriction: [
+        'https://openactive.io/NoRestriction',
+        'https://openactive.io/MaleOnly',
+        'https://openactive.io/FemaleOnly',
+      ],
+    };
+
+    const nodeToTest = new ModelNode(
+      '$',
+      data,
+      null,
+      model,
+    );
+    const errors = await rule.validate(nodeToTest);
+
+    expect(errors.length).toBe(1);
+
+    expect(errors[0].message).toBe('This property cannot be an array. Must be one of:\n\n{{allowedValues}}.');
     expect(errors[0].severity).toBe(ValidationErrorSeverity.FAILURE);
   });
 });

--- a/src/rules/core/value-in-options-rule.js
+++ b/src/rules/core/value-in-options-rule.js
@@ -50,7 +50,7 @@ module.exports = class ValueInOptionsRule extends Rule {
       && typeof fieldObj !== 'undefined'
     ) {
       let isInOptions = true;
-      let cannotBeArray = false;
+      let isArrayButCannotBeArray = false;
       let allowedOptions;
       let testType;
       const possibleTypes = fieldObj.getAllPossibleTypes();
@@ -76,19 +76,19 @@ module.exports = class ValueInOptionsRule extends Rule {
           for (const value of fieldValue) {
             if (allowedOptions.indexOf(value) < 0) {
               isInOptions = false;
-              cannotBeArray = false;
+              isArrayButCannotBeArray = false;
               singleFieldValue = value;
               break;
             }
           }
         } else if (fieldValue instanceof Array && !fieldObj.canBeArray()) {
-          cannotBeArray = true;
+          isArrayButCannotBeArray = true;
         } else if (allowedOptions.indexOf(fieldValue) < 0) {
           isInOptions = false;
         }
       }
 
-      if (cannotBeArray) {
+      if (isArrayButCannotBeArray) {
         errors.push(
           this.createError(
             'fieldArray',

--- a/src/rules/core/value-in-options-rule.js
+++ b/src/rules/core/value-in-options-rule.js
@@ -16,7 +16,17 @@ module.exports = class ValueInOptionsRule extends Rule {
           message: 'Value `"{{value}}"` is not in the allowed values for this property. Must be one of:\n\n{{allowedValues}}.',
           sampleValues: {
             value: 'Male',
-            allowedValues: '<ul><li>`"https://openactive.io/Female"`</li><li>`"https://openactive.io/Male"`</li><li>`"https://openactive.io/None"`</li></ul>',
+            allowedValues: '<ul><li>`"https://openactive.io/Female"`</li><li>`"https://openactive.io/Male"`</li><li>`"https://openactive.io/NoRestriction"`</li></ul>',
+          },
+          category: ValidationErrorCategory.CONFORMANCE,
+          severity: ValidationErrorSeverity.FAILURE,
+          type: ValidationErrorType.FIELD_NOT_IN_DEFINED_VALUES,
+        },
+        fieldArray: {
+          message: 'This property cannot be an array. Must be one of:\n\n{{allowedValues}}.',
+          sampleValues: {
+            value: 'Male',
+            allowedValues: '<ul><li>`"https://openactive.io/Female"`</li><li>`"https://openactive.io/Male"`</li><li>`"https://openactive.io/NoRestriction"`</li></ul>',
           },
           category: ValidationErrorCategory.CONFORMANCE,
           severity: ValidationErrorSeverity.FAILURE,
@@ -40,6 +50,7 @@ module.exports = class ValueInOptionsRule extends Rule {
       && typeof fieldObj !== 'undefined'
     ) {
       let isInOptions = true;
+      let cannotBeArray = false;
       let allowedOptions;
       let testType;
       const possibleTypes = fieldObj.getAllPossibleTypes();
@@ -65,16 +76,29 @@ module.exports = class ValueInOptionsRule extends Rule {
           for (const value of fieldValue) {
             if (allowedOptions.indexOf(value) < 0) {
               isInOptions = false;
+              cannotBeArray = false;
               singleFieldValue = value;
               break;
             }
           }
+        } else if (fieldValue instanceof Array && !fieldObj.canBeArray()) {
+          cannotBeArray = true;
         } else if (allowedOptions.indexOf(fieldValue) < 0) {
           isInOptions = false;
         }
       }
 
-      if (!isInOptions) {
+      if (cannotBeArray) {
+        errors.push(
+          this.createError(
+            'fieldArray',
+            {
+              value: singleFieldValue,
+              allowedValues: `<ul><li>\`"${allowedOptions.join('"`</li><li>`"')}"\`</li></ul>`,
+            },
+          ),
+        );
+      } else if (!isInOptions) {
         errors.push(
           this.createError(
             'default',


### PR DESCRIPTION
# #305 

This rule has been updated to return a different error message in the instance that the field value is an array when it should not be