### PR TITLE
core: Update fields-correct-value-type to handle allowReferencing and…

### DIFF
--- a/src/rules/core/fields-correct-type-rule.js
+++ b/src/rules/core/fields-correct-type-rule.js
@@ -290,6 +290,8 @@ module.exports = class FieldsCorrectTypeRule extends Rule {
           }
         } else if (fieldObj.allowReferencing && fieldObj.detectType(fieldValue) === 'https://schema.org/URL') {
           // Do nothing, as referencing via a URL that matches an @id elsewhere is allowed
+          // Don't do literally nothing as this still runs this.createError with undefined, instead return empty
+          return [];
         } else {
           testKey = 'singleType';
           messageValues = {


### PR DESCRIPTION
… URL field type

I couldn't find much in the docs about this, so any guidance appeciated. This resolves the issue, but I wasn't sure of the exact relationship between `allowReferencing` and URL type.