### PR TITLE
fix: Incorrect validation of extension types

### DIFF
--- a/src/rules/core/fields-not-in-model-rule.js
+++ b/src/rules/core/fields-not-in-model-rule.js
@@ -298,6 +298,14 @@ module.exports = class FieldsNotInModelRule extends Rule {
     if (field === '@context') {
       return [];
     }
+    // Don't do this check for cases where the JSON-LD type does not match the expected model
+    // Other rules will raise an error if the type itself is invalid, and if this type is an
+    // extension the validator cannot yet validate properties within the type anyway,
+    // so in either case this rule should not run.
+    // TODO: Remove this and improve the rule to validate beta and extension types
+    if (node.model.isJsonLd && node.model.type !== node.getValue('type')) {
+      return [];
+    }
     let errors = [];
     let testKey = null;
     let messageValues;


### PR DESCRIPTION
Fixes #421. The validator currently outputs a message that `Type <extension property> is not recognised by the validator, as it is not part of the Modelling Opportunity Data specification or schema.org, and cannot be checked for validity.`. Therefore this fix makes this support consistent by disabling the misbehaving rule for extensions.

A better long-term solution would be to update the validator to validate extensions and beta types properly, which is captured in #358.